### PR TITLE
Added version constraints for nokogiri and parallel

### DIFF
--- a/hooks.gemspec
+++ b/hooks.gemspec
@@ -7,6 +7,8 @@ Gem::Specification.new do |s|
   s.summary = 'Pre-commit hooks for Chef projects'
   s.add_runtime_dependency 'cookstyle', '~> 3.0'
   s.add_runtime_dependency 'foodcritic', '~> 15.1'
+  s.add_runtime_dependency 'nokogiri', '= 1.13.10'
+  s.add_runtime_dependency 'parallel', '= 1.24.0'
   s.bindir = 'hooks'
   s.executables << 'run_cookstyle.rb'
   s.executables << 'run_foodcritic.rb'


### PR DESCRIPTION
This may not be the ultimate way forward but there are a bunch of version conflicts in some of the libraries like rubocop if you upgrade to the minimum ruby version for the latest nokogiri + parallel. These 2 versions are the minimum supported version for the libs that work on 2.6.10 even though that version of ruby is out of support by quite a long time.

Submitting a PR just because this is the way i worked around mine. 